### PR TITLE
Allow defining a node caption with a function.

### DIFF
--- a/dist/neovis.js
+++ b/dist/neovis.js
@@ -36409,7 +36409,12 @@ class NeoVis {
         }
 
         // node caption
-        node['label'] = n.properties[captionKey] || label || "";
+        if (typeof captionKey === "function") {
+            node['label'] = captionKey(n);
+        }
+        else {
+            node['label'] = n.properties[captionKey] || label || "";
+        }
 
         // community
         // behavior: color by value of community property (if set in config), then color by label

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -113,7 +113,12 @@ export default class NeoVis {
         }
 
         // node caption
-        node['label'] = n.properties[captionKey] || label || "";
+        if (typeof captionKey === "function") {
+            node['label'] = captionKey(n);
+        }
+        else {
+            node['label'] = n.properties[captionKey] || label || "";
+        }
 
         // community
         // behavior: color by value of community property (if set in config), then color by label


### PR DESCRIPTION
This might come in handy when a node caption is a combination of several attributes instead of a single one. The way to use it would be to define the usual configuration with a `caption` entry that, instead of a constant value, contains a function that takes as first parameter the node and as result outputs the desired caption.

Following the example on the README file:
```html
<script type="text/javascript">

        var viz;

        function draw() {
            var config = {
                container_id: "viz",
                server_url: "bolt://localhost:7687",
                server_user: "neo4j",
                server_password: "sorts-swims-burglaries",
                labels: {
                    "Character": {
                        /* <new functionality> */
                        "caption": (node) => node.properties.name.toUpperCase(),
                        /* </new functionality> */
                        "size": "pagerank",
                        "community": "community"
                    }
                },
                relationships: {
                    "INTERACTS": {
                        "thickness": "weight",
                        "caption": false
                    }
                },
                initial_cypher: "MATCH (n)-[r:INTERACTS]->(m) RETURN *"
            };

            viz = new NeoVis.default(config);
            viz.render();
        }
    </script>```