### PR TITLE
add draggable nodes

### DIFF
--- a/src/neovis.js
+++ b/src/neovis.js
@@ -278,6 +278,16 @@ export default class NeoVis {
 					await Promise.all(dataBuildPromises);
 					session.close();
 					let options = {
+						interaction: {
+						    dragNodes: true,
+						    dragView: true,
+						    hover: true,
+						    hoverConnectedEdges: true,
+						    multiselect: true,
+						    selectable: true,
+						    selectConnectedEdges: true,
+						    zoomView: true,
+						},
 						nodes: {
 							shape: 'dot',
 							font: {
@@ -348,6 +358,16 @@ export default class NeoVis {
 					// );
 					this._network = new vis.Network(container, this._data, options);
 					this._consoleLog('completed');
+					this._network.on('dragEnd', (params) => {
+					    if (params.nodes.length > 0) {
+						this._data.nodes.update({ id: params.nodes[0], fixed: { x: true, y: true } });
+					    }
+					});
+					this._network.on('dragStart', (params) => {
+					    if (params.nodes.length > 0) {
+						this._data.nodes.update({ id: params.nodes[0], fixed: { x: false, y: false } });
+					    }
+					});
 					setTimeout(
 						() => {
 							this._network.stopSimulation();

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -368,6 +368,11 @@ export default class NeoVis {
 						this._data.nodes.update({ id: params.nodes[0], fixed: { x: false, y: false } });
 					    }
 					});
+					this._network.on('doubleClick',(params) => {
+					    if (params.nodes.length > 0) {
+						this._data.nodes.update({ id: params.nodes[0], fixed: { x: false, y: false } });
+					    } 
+                                        });
 					setTimeout(
 						() => {
 							this._network.stopSimulation();


### PR DESCRIPTION
Firstly, thanks for this awesome little library to quickly and easily visualise a neo4j database.

This is a minor change that adds the ability to create draggable nodes. I've found that this is really handy after drawing a graph initially, as users can then drag nodes where they like and make the visualisation  easier to interpret.

I tried a couple of implementations, eg; [this](https://github.com/almende/vis/issues/315) didn't work. Eventually [this](https://github.com/cgps-dev/chartjs-plugin-zoom/commit/46af411f73a416e9454fb0d658bf0d9a148377ff) implementation from a chartjs plugin worked the best.

Please let me know if there's any issues. 