### PR TITLE
Fix type error -- registerOnEvent should have void return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export interface INeovisConfig {
         [relationship: string]: IRelationshipConfig
     };
     arrows?: boolean;
-    hierarchical? :boolean;
+    hierarchical?: boolean;
     hierarchical_sort_method?: "hubsize" | "directed";
     initial_cypher?: string;
     console_debug?: boolean;
@@ -34,7 +34,7 @@ declare class Neovis {
     constructor(config: INeovisConfig);
     render(): void;
     clearNetwork(): void;
-    registerOnEvent(eventType:string, handler: (event: any) => void);
+    registerOnEvent(eventType: string, handler: (event: any) => void): void;
     reinit(config: INeovisConfig): void;
     reload(): void;
     stabilize(): void;


### PR DESCRIPTION
Currently using strict mode in TypeScript produces this error,

```
ERROR in /home/amoe/dev/playgrounds/node_modules/neovis.js/index.d.ts
37:5 'registerOnEvent', which lacks return-type annotation, implicitly has an 'any' return type.
    35 |     render(): void;
    36 |     clearNetwork(): void;
  > 37 |     registerOnEvent(eventType:string, handler: (event: any) => void);
       |     ^
    38 |     reinit(config: INeovisConfig): void;
    39 |     reload(): void;
    40 |     stabilize(): void;
```

PR fixes this omission.