### PR TITLE
Ability to update visualization with Cypher

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ will build `dist/neovis.js` and `dist/neovis-without-dependencies.js`
 * `Neovis.reload()`
 * `Neovis.stabilize()`
 * `Neovis.renderWithCypher(statement)`
+* `Neovis.updateWithCypher(statement)`
 
 * `config`
 
@@ -229,7 +230,11 @@ Stop the physics simulation.
 
 ### `Neovis.renderWithCypher(statement)`
 
-Render a new visualization with results from a Cypher statement. Any `Node` and `Relationship` objects returned in the Cypher query will be rendered in the visualization. Paths are not currently supported. 
+Render a new visualization with results from a Cypher statement. Any `Node` and `Relationship` objects returned in the Cypher query will be rendered in the visualization. Paths are not currently supported.
+
+### `Neovis.updateWithCypher(statement)`
+
+Update the current visualization with results from a Cypher statement. Any `Node` and `Relationship` objects returned in the Cypher query will be rendered in the visualization. Paths are not currently supported.
 
 ### `config`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,8 @@ declare class Neovis {
     reload(): void;
     stabilize(): void;
     renderWithCypher(query: string): void;
+    updateWithCypher(query: string): void;
+
 }
 
 export default Neovis;

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -253,16 +253,18 @@ export default class NeoVis {
 
 	// public API
 
-	render() {
+	render(query) {
 
 		// connect to Neo4j instance
 		// run query
 		let recordCount = 0;
 
 		let session = this._driver.session();
+
+		const _query = query ? query : this._query; 
 		const dataBuildPromises = [];
 		session
-			.run(this._query, {limit: 30})
+			.run(_query, {limit: 30})
 			.subscribe({
 				onNext: (record) => {
 					recordCount++;
@@ -322,73 +324,79 @@ export default class NeoVis {
 				onCompleted: async () => {
 					await Promise.all(dataBuildPromises);
 					session.close();
-					let options = {
-						nodes: {
-							shape: 'dot',
-							font: {
-								size: 26,
-								strokeWidth: 7
+
+					if(this._network && this._network.body.data.nodes.length > 0) {
+						this._data.nodes.update(Object.values(this._nodes));
+						this._data.edges.update(Object.values(this._edges));
+					} else {
+						let options = {
+							nodes: {
+								shape: 'dot',
+								font: {
+									size: 26,
+									strokeWidth: 7
+								},
+								scaling: {
+								}
 							},
-							scaling: {
-							}
-						},
-						edges: {
-							arrows: {
-								to: {enabled: this._config.arrows || false} // FIXME: handle default value
+							edges: {
+								arrows: {
+									to: {enabled: this._config.arrows || false} // FIXME: handle default value
+								},
+								length: 200
 							},
-							length: 200
-						},
-						layout: {
-							improvedLayout: false,
-							hierarchical: {
-								enabled: this._config.hierarchical || false,
-								sortMethod: this._config.hierarchical_sort_method || 'hubsize'
+							layout: {
+								improvedLayout: false,
+								hierarchical: {
+									enabled: this._config.hierarchical || false,
+									sortMethod: this._config.hierarchical_sort_method || 'hubsize'
+								}
+							},
+							physics: { // TODO: adaptive physics settings based on size of graph rendered
+								// enabled: true,
+								// timestep: 0.5,
+								// stabilization: {
+								//     iterations: 10
+								// }
+	
+								adaptiveTimestep: true,
+								// barnesHut: {
+								//     gravitationalConstant: -8000,
+								//     springConstant: 0.04,
+								//     springLength: 95
+								// },
+								stabilization: {
+									iterations: 200,
+									fit: true
+								}
 							}
-						},
-						physics: { // TODO: adaptive physics settings based on size of graph rendered
-							// enabled: true,
-							// timestep: 0.5,
-							// stabilization: {
-							//     iterations: 10
-							// }
-
-							adaptiveTimestep: true,
-							// barnesHut: {
-							//     gravitationalConstant: -8000,
-							//     springConstant: 0.04,
-							//     springLength: 95
-							// },
-							stabilization: {
-								iterations: 200,
-								fit: true
-							}
-						}
-					};
-
-					const container = this._container;
-					this._data = {
-						nodes: new vis.DataSet(Object.values(this._nodes)),
-						edges: new vis.DataSet(Object.values(this._edges))
-					};
-
-					this._consoleLog(this._data.nodes);
-					this._consoleLog(this._data.edges);
-
-					// Create duplicate node for any this reference relationships
-					// NOTE: Is this only useful for data model type data
-					// this._data.edges = this._data.edges.map(
-					//     function (item) {
-					//          if (item.from == item.to) {
-					//             const newNode = this._data.nodes.get(item.from)
-					//             delete newNode.id;
-					//             const newNodeIds = this._data.nodes.add(newNode);
-					//             this._consoleLog("Adding new node and changing this-ref to node: " + item.to);
-					//             item.to = newNodeIds[0];
-					//          }
-					//          return item;
-					//     }
-					// );
-					this._network = new vis.Network(container, this._data, options);
+						};
+	
+						const container = this._container;
+						this._data = {
+							nodes: new vis.DataSet(Object.values(this._nodes)),
+							edges: new vis.DataSet(Object.values(this._edges))
+						};
+	
+						this._consoleLog(this._data.nodes);
+						this._consoleLog(this._data.edges);
+	
+						// Create duplicate node for any this reference relationships
+						// NOTE: Is this only useful for data model type data
+						// this._data.edges = this._data.edges.map(
+						//     function (item) {
+						//          if (item.from == item.to) {
+						//             const newNode = this._data.nodes.get(item.from)
+						//             delete newNode.id;
+						//             const newNodeIds = this._data.nodes.add(newNode);
+						//             this._consoleLog("Adding new node and changing this-ref to node: " + item.to);
+						//             item.to = newNodeIds[0];
+						//          }
+						//          return item;
+						//     }
+						// );
+						this._network = new vis.Network(container, this._data, options);
+					}
 					this._consoleLog('completed');
 					setTimeout(
 						() => {
@@ -470,6 +478,15 @@ export default class NeoVis {
 		this.clearNetwork();
 		this._query = query;
 		this.render();
+	}
+
+	/**
+	 * Execute an arbitrary Cypher query and update the current visualization, retaning current nodes
+	 * This function will not change the original query given by renderWithCypher or the inital cypher.
+	 * @param query 
+	 */
+	updateWithCypher(query) {
+		this.render(query);
 	}
 
 // configure exports based on environment (ie Node.js or browser)


### PR DESCRIPTION
This PR contains:

 - `updateWithCypher`, makes it easy to run a Cypher query, and add its result to the current graph. (Useful for expanding child relations for certain nodes, for instance.)

It does not change the `this._query` variable, so when calling `reload()` the original query is executed again, I don't know if this is the behavior is favorable though.