### PR TITLE
add nodes and edges to completed event data

### DIFF
--- a/__tests__/neovis.tests.js
+++ b/__tests__/neovis.tests.js
@@ -157,7 +157,9 @@ describe('Neovis', () => {
 			neovis.render();
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(2);
+			expect(Object.keys(neovis.nodes).length).toBe(2);
 			expect(neovis._data.edges.length).toBe(1);
+			expect(Object.keys(neovis.edges).length).toBe(1);
 		});
 
 		it('should save multiple records from different types', async () => {
@@ -175,7 +177,9 @@ describe('Neovis', () => {
 			neovis.render();
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(5);
+			expect(Object.keys(neovis.nodes).length).toBe(5);
 			expect(neovis._data.edges.length).toBe(2);
+			expect(Object.keys(neovis.edges).length).toBe(2);
 		});
 	});
 

--- a/__tests__/neovis.tests.js
+++ b/__tests__/neovis.tests.js
@@ -157,9 +157,9 @@ describe('Neovis', () => {
 			neovis.render();
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(2);
-			expect(Object.keys(neovis.nodes).length).toBe(2);
+			expect(neovis.nodes.length).toBe(2);
 			expect(neovis._data.edges.length).toBe(1);
-			expect(Object.keys(neovis.edges).length).toBe(1);
+			expect(neovis.edges.length).toBe(1);
 		});
 
 		it('should save multiple records from different types', async () => {
@@ -177,9 +177,9 @@ describe('Neovis', () => {
 			neovis.render();
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(5);
-			expect(Object.keys(neovis.nodes).length).toBe(5);
+			expect(neovis.nodes.length).toBe(5);
 			expect(neovis._data.edges.length).toBe(2);
-			expect(Object.keys(neovis.edges).length).toBe(2);
+			expect(neovis.edges.length).toBe(2);
 		});
 
 		it('should save raw records', async () => {

--- a/__tests__/neovis.tests.js
+++ b/__tests__/neovis.tests.js
@@ -158,8 +158,10 @@ describe('Neovis', () => {
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(2);
 			expect(Object.keys(neovis.nodes).length).toBe(2);
+			expect(Object.keys(neovis.neo4jNodes).length).toBe(2);
 			expect(neovis._data.edges.length).toBe(1);
 			expect(Object.keys(neovis.edges).length).toBe(1);
+			expect(Object.keys(neovis.neo4jEdges).length).toBe(1);
 		});
 
 		it('should save multiple records from different types', async () => {
@@ -178,8 +180,10 @@ describe('Neovis', () => {
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(5);
 			expect(Object.keys(neovis.nodes).length).toBe(5);
+			expect(Object.keys(neovis.neo4jNodes).length).toBe(5);
 			expect(neovis._data.edges.length).toBe(2);
 			expect(Object.keys(neovis.edges).length).toBe(2);
+			expect(Object.keys(neovis.neo4jEdges).length).toBe(2);
 		});
 	});
 

--- a/__tests__/neovis.tests.js
+++ b/__tests__/neovis.tests.js
@@ -35,7 +35,7 @@ describe('Neovis', () => {
 				}
 			};
 			const neovis = new Neovis(config);
-			expect(neovis._config.labels.a).toMatchObject({caption: 'name', test: 'test'});
+			expect(neovis._config.labels.a).toMatchObject({ caption: 'name', test: 'test' });
 		});
 		it('should not change the config sent', () => {
 			config = {
@@ -56,7 +56,7 @@ describe('Neovis', () => {
 					}
 				}
 			};
-			const configTemp = {...config};
+			const configTemp = { ...config };
 			new Neovis(config);
 			expect(config).toMatchObject(configTemp);
 		});
@@ -86,7 +86,7 @@ describe('Neovis', () => {
 				}
 			};
 			const neovis = new Neovis(config);
-			expect(neovis._config.labels.a).toMatchObject({caption: 'name', test: 'test'});
+			expect(neovis._config.labels.a).toMatchObject({ caption: 'name', test: 'test' });
 		});
 		it('should override default config if specific relationship have one', () => {
 			config.relationships = {
@@ -108,12 +108,12 @@ describe('Neovis', () => {
 
 	describe('Neovis default behavior', () => {
 		beforeEach(() => {
-			neovis = new Neovis({initial_cypher, container_id});
+			neovis = new Neovis({ initial_cypher, container_id });
 		});
 
 		it('should call run with query', () => {
 			neovis.render();
-			expect(Neo4jMock.mockSessionRun).toHaveBeenCalledWith(initial_cypher, {limit: 30});
+			expect(Neo4jMock.mockSessionRun).toHaveBeenCalledWith(initial_cypher, { limit: 30 });
 		});
 
 		it('should call completed when complete', () => new Promise(done => {
@@ -158,10 +158,8 @@ describe('Neovis', () => {
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(2);
 			expect(Object.keys(neovis.nodes).length).toBe(2);
-			expect(Object.keys(neovis.neo4jNodes).length).toBe(2);
 			expect(neovis._data.edges.length).toBe(1);
 			expect(Object.keys(neovis.edges).length).toBe(1);
-			expect(Object.keys(neovis.neo4jEdges).length).toBe(1);
 		});
 
 		it('should save multiple records from different types', async () => {
@@ -180,10 +178,23 @@ describe('Neovis', () => {
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.length).toBe(5);
 			expect(Object.keys(neovis.nodes).length).toBe(5);
-			expect(Object.keys(neovis.neo4jNodes).length).toBe(5);
 			expect(neovis._data.edges.length).toBe(2);
 			expect(Object.keys(neovis.edges).length).toBe(2);
-			expect(Object.keys(neovis.neo4jEdges).length).toBe(2);
+		});
+
+		it('should save raw records', async () => {
+			const firstNode = testUtils.makeNode([label1]);
+			const secondNode = testUtils.makeNode([label1]);
+			const relationship = testUtils.makeRelationship(relationshipType, firstNode, secondNode);
+			testUtils.mockNormalRunSubscribe([
+				testUtils.makeRecord([firstNode, secondNode, relationship])
+			]);
+			neovis.render();
+			await testUtils.neovisRenderDonePromise(neovis);
+			expect(neovis._data.nodes.get(1).raw).toBeDefined();
+			expect(neovis._data.nodes.get(2).raw).toBeDefined();
+			// Map neovis._data.edges is empty in test mode
+			//expect(neovis._data.edges.get(1).raw).toBeDefined();
 		});
 	});
 
@@ -225,7 +236,7 @@ describe('Neovis', () => {
 	describe('neovis with update cypher', () => {
 		const updateWithCypher = 'updateCypher';
 		beforeEach(() => {
-			neovis = new Neovis({initial_cypher, container_id});
+			neovis = new Neovis({ initial_cypher, container_id });
 		});
 
 		it('should call updateWithCypher and add the new node to visualization', async () => {
@@ -365,7 +376,7 @@ describe('Neovis', () => {
 				initial_cypher: initial_cypher
 			};
 			neovis = new Neovis(config);
-			const node1 = testUtils.makeNode([label1], {[intProperity]: intProperityValue});
+			const node1 = testUtils.makeNode([label1], { [intProperity]: intProperityValue });
 			testUtils.mockFullRunSubscribe({
 				[initial_cypher]: {
 					default: [testUtils.makeRecord([node1])]
@@ -388,7 +399,7 @@ describe('Neovis', () => {
 				initial_cypher: initial_cypher
 			};
 			neovis = new Neovis(config);
-			const node1 = testUtils.makeNode([label1], {[floatProperity]: floatProperityValue});
+			const node1 = testUtils.makeNode([label1], { [floatProperity]: floatProperityValue });
 			testUtils.mockFullRunSubscribe({
 				[initial_cypher]: {
 					default: [testUtils.makeRecord([node1])]

--- a/__tests__/neovis.tests.js
+++ b/__tests__/neovis.tests.js
@@ -193,8 +193,7 @@ describe('Neovis', () => {
 			await testUtils.neovisRenderDonePromise(neovis);
 			expect(neovis._data.nodes.get(1).raw).toBeDefined();
 			expect(neovis._data.nodes.get(2).raw).toBeDefined();
-			// Map neovis._data.edges is empty in test mode
-			//expect(neovis._data.edges.get(1).raw).toBeDefined();
+			expect(neovis._data.edges.get(3).raw).toBeDefined();
 		});
 	});
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,33 +35,9 @@ export interface INeovisConfig {
     trust?: "TRUST_ALL_CERTIFICATES" | "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES";
 }
 
-export interface INode {
-    group: string;
-    id: number;
-    label: string;
-    raw: any;
-    shape: string;
-    title: string;
-    value: number;
-}
-
-export interface IEdge {
-    from: number;
-    id: number;
-    label: string;
-    raw: any;
-    title: string;
-    to: number;
-    value: number;
-}
-
 declare class Neovis {
-    nodes: {
-        [id: number]: INode,
-    }
-    edges: {
-        [id: number]: IEdge,
-    }
+    nodes: any;
+    edges: any;
     constructor(config: INeovisConfig);
     render(): void;
     clearNetwork(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,33 @@ export interface INeovisConfig {
     trust?: "TRUST_ALL_CERTIFICATES" | "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES";
 }
 
+export interface INode {
+    group: string;
+    id: number;
+    label: string;
+    raw: any;
+    shape: string;
+    title: string;
+    value: number;
+}
+
+export interface IEdge {
+    from: number;
+    id: number;
+    label: string;
+    raw: any;
+    title: string;
+    to: number;
+    value: number;
+}
+
 declare class Neovis {
+    nodes: {
+        [id: number]: INode,
+    }
+    edges: {
+        [id: number]: IEdge,
+    }
     constructor(config: INeovisConfig);
     render(): void;
     clearNetwork(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
+import { DataSet } from "vis-data";
+import { Node as VisNode, Edge as VisEdge } from "vis-network";
+import { Node as Neo4jNode, Relationship as Neo4jRelationship } from "neo4j-driver";
+
 export const NEOVIS_DEFAULT_CONFIG: unique symbol;
 
 export interface ILabelConfig {
@@ -35,10 +39,18 @@ export interface INeovisConfig {
     trust?: "TRUST_ALL_CERTIFICATES" | "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES";
 }
 
+export interface INode extends VisNode {
+    raw: Neo4jNode
+}
+
+export interface IEdge extends VisEdge {
+    raw: Neo4jRelationship
+}
+
 declare class Neovis {
-    nodes: any;
-    edges: any;
     constructor(config: INeovisConfig);
+    get nodes(): DataSet<INode>;
+    get edges(): DataSet<IEdge>;
     render(): void;
     clearNetwork(): void;
     registerOnEvent(eventType: string, handler: (event: any) => void): void;

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.8.4",
     "neo4j-driver": "^4.1.0",
+    "vis-data": "^7.0.0",
     "vis-network": "^7.3.5"
   },
   "jest": {

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -8,29 +8,11 @@ import { EventController, CompletionEvent, ClickEdgeEvent, ClickNodeEvent, Error
 export const NEOVIS_DEFAULT_CONFIG = Symbol();
 
 export default class NeoVis {
-	_neo4jNodes = {};
-	_neo4jEdges = {};
 	_nodes = {};
 	_edges = {};
 	_data = {};
 	_network = null;
 	_events = new EventController();
-
-	/**
-	 * Get current neo4j nodes from the graph
-	 * @returns {Neo4j.Node} neo4jNodes
-	 */
-	get neo4jNodes() {
-		return this._neo4jNodes;
-	}
-
-	/**
-	 * Get current neo4j edges from the graph
-	 * @returns {Neo4j.Relationship}
-	 */
-	get neo4jEdges() {
-		return this._neo4jEdges;
-	}
 
 	/**
 	 * Get current vis nodes from the graph
@@ -151,9 +133,7 @@ export default class NeoVis {
 		) || Object.keys(neo4jNode.properties);
 
 		node.id = neo4jNode.identity.toInt();
-
-		// save raw neo4j node
-		this._neo4jNodes[node.id] = neo4jNode;
+		node.raw = neo4jNode;
 
 		// node size
 
@@ -264,9 +244,7 @@ export default class NeoVis {
 		edge.id = r.identity.toInt();
 		edge.from = r.start.toInt();
 		edge.to = r.end.toInt();
-
-		// save raw neo4j edge
-		this._neo4jEdges[edge.id] = r;
+		edge.raw = r;
 
 		// hover tooltip. show all properties in the format <strong>key:</strong> value
 		edge.title = '';

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -18,15 +18,15 @@ export default class NeoVis {
 	 * Get current nodes from the graph
 	 */
 	get nodes() {
-    return this._nodes;
+		return this._nodes;
 	}
 	
 	/**
 	 * Get current edges from the graph
 	 */
 	get edges() {
-    return this._edges;
-  }
+		return this._edges;
+	}
 
 	/**
 	 *

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -8,6 +8,8 @@ import { EventController, CompletionEvent, ClickEdgeEvent, ClickNodeEvent, Error
 export const NEOVIS_DEFAULT_CONFIG = Symbol();
 
 export default class NeoVis {
+	_neo4jNodes = {};
+	_neo4jEdges = {};
 	_nodes = {};
 	_edges = {};
 	_data = {};
@@ -15,14 +17,30 @@ export default class NeoVis {
 	_events = new EventController();
 
 	/**
-	 * Get current nodes from the graph
+	 * Get current neo4j nodes from the graph
+	 * @returns {Neo4j.Node} neo4jNodes
+	 */
+	get neo4jNodes() {
+		return this._neo4jNodes;
+	}
+
+	/**
+	 * Get current neo4j edges from the graph
+	 * @returns {Neo4j.Relationship}
+	 */
+	get neo4jEdges() {
+		return this._neo4jEdges;
+	}
+
+	/**
+	 * Get current vis nodes from the graph
 	 */
 	get nodes() {
 		return this._nodes;
 	}
-	
+
 	/**
-	 * Get current edges from the graph
+	 * Get current vis edges from the graph
 	 */
 	get edges() {
 		return this._edges;
@@ -65,7 +83,7 @@ export default class NeoVis {
 					...config,
 					labels: {
 						...config.labels,
-						[key]: {...config.labels[NEOVIS_DEFAULT_CONFIG], ...config.labels[key]}
+						[key]: { ...config.labels[NEOVIS_DEFAULT_CONFIG], ...config.labels[key] }
 					}
 				};
 			}
@@ -77,7 +95,7 @@ export default class NeoVis {
 					...config,
 					relationships: {
 						...config.relationships,
-						[key]: {...config.relationships[NEOVIS_DEFAULT_CONFIG], ...config.relationships[key]}
+						[key]: { ...config.relationships[NEOVIS_DEFAULT_CONFIG], ...config.relationships[key] }
 					}
 				};
 			}
@@ -92,7 +110,7 @@ export default class NeoVis {
 				encrypted: this._encrypted,
 				trust: this._trust,
 				maxConnectionPoolSize: 100,
-				connectionAcquisitionTimeout:10000,
+				connectionAcquisitionTimeout: 10000,
 			}
 		);
 		this._database = config.server_database;
@@ -134,6 +152,9 @@ export default class NeoVis {
 
 		node.id = neo4jNode.identity.toInt();
 
+		// save raw neo4j node
+		this._neo4jNodes[node.id] = neo4jNode;
+
 		// node size
 
 		if (sizeCypher) {
@@ -144,7 +165,7 @@ export default class NeoVis {
 			node.value = 1.0;
 			const session = this._driver.session(this._database && { database: this._database });
 			try {
-				const result = await session.readTransaction(tx => tx.run(sizeCypher, {id: Neo4j.int(node.id)}));
+				const result = await session.readTransaction(tx => tx.run(sizeCypher, { id: Neo4j.int(node.id) }));
 				for (let record of result.records) {
 					record.forEach((v) => {
 						if (typeof v === 'number') {
@@ -244,6 +265,9 @@ export default class NeoVis {
 		edge.from = r.start.toInt();
 		edge.to = r.end.toInt();
 
+		// save raw neo4j edge
+		this._neo4jEdges[edge.id] = r;
+
 		// hover tooltip. show all properties in the format <strong>key:</strong> value
 		edge.title = '';
 		for (let key in r.properties) {
@@ -281,7 +305,7 @@ export default class NeoVis {
 		}
 		return edge;
 	}
-    
+
 	propertyToString(key, value) {
 		if (Array.isArray(value) && value.length > 1) {
 			let out = `<strong>${key}:</strong><br /><ul>`;
@@ -290,7 +314,7 @@ export default class NeoVis {
 			}
 			return out + '</ul>';
 		}
-		return  `<strong>${key}:</strong> ${value}<br>`;
+		return `<strong>${key}:</strong> ${value}<br>`;
 	}
 
 	// public API
@@ -304,7 +328,7 @@ export default class NeoVis {
 		let session = this._driver.session(this._database && { database: this._database });
 		const dataBuildPromises = [];
 		session
-			.run(_query, {limit: 30})
+			.run(_query, { limit: 30 })
 			.subscribe({
 				onNext: (record) => {
 					recordCount++;
@@ -365,7 +389,7 @@ export default class NeoVis {
 					await Promise.all(dataBuildPromises);
 					session.close();
 
-					if(this._network && this._network.body.data.nodes.length > 0) {
+					if (this._network && this._network.body.data.nodes.length > 0) {
 						this._data.nodes.update(Object.values(this._nodes));
 						this._data.edges.update(Object.values(this._edges));
 					} else {
@@ -381,7 +405,7 @@ export default class NeoVis {
 							},
 							edges: {
 								arrows: {
-									to: {enabled: this._config.arrows || false} // FIXME: handle default value
+									to: { enabled: this._config.arrows || false } // FIXME: handle default value
 								},
 								length: 200
 							},
@@ -398,7 +422,7 @@ export default class NeoVis {
 								// stabilization: {
 								//     iterations: 10
 								// }
-	
+
 								adaptiveTimestep: true,
 								// barnesHut: {
 								//     gravitationalConstant: -8000,
@@ -411,16 +435,16 @@ export default class NeoVis {
 								}
 							}
 						};
-	
+
 						const container = this._container;
 						this._data = {
 							nodes: new vis.DataSet(Object.values(this._nodes)),
 							edges: new vis.DataSet(Object.values(this._edges))
 						};
-	
+
 						this._consoleLog(this._data.nodes);
 						this._consoleLog(this._data.edges);
-	
+
 						// Create duplicate node for any this reference relationships
 						// NOTE: Is this only useful for data model type data
 						// this._data.edges = this._data.edges.map(
@@ -444,22 +468,22 @@ export default class NeoVis {
 						},
 						10000
 					);
-					this._events.generateEvent(CompletionEvent, {record_count: recordCount});
+					this._events.generateEvent(CompletionEvent, { record_count: recordCount });
 
 					let neoVis = this;
 					this._network.on('click', function (params) {
 						if (params.nodes.length > 0) {
 							let nodeId = this.getNodeAt(params.pointer.DOM);
-							neoVis._events.generateEvent(ClickNodeEvent, {nodeId: nodeId, node: neoVis._nodes[nodeId]});
+							neoVis._events.generateEvent(ClickNodeEvent, { nodeId: nodeId, node: neoVis._nodes[nodeId] });
 						} else if (params.edges.length > 0) {
 							let edgeId = this.getEdgeAt(params.pointer.DOM);
-							neoVis._events.generateEvent(ClickEdgeEvent, {edgeId: edgeId, edge: neoVis._edges[edgeId]});
+							neoVis._events.generateEvent(ClickEdgeEvent, { edgeId: edgeId, edge: neoVis._edges[edgeId] });
 						}
 					});
 				},
 				onError: (error) => {
 					this._consoleLog(error, 'error');
-					this._events.generateEvent(ErrorEvent, {error_msg: error});
+					this._events.generateEvent(ErrorEvent, { error_msg: error });
 				}
 			});
 	}
@@ -468,6 +492,8 @@ export default class NeoVis {
 	 * Clear the data for the visualization
 	 */
 	clearNetwork() {
+		this._neo4jNodes = {};
+		this._neo4jEdges = {};
 		this._nodes = {};
 		this._edges = {};
 		this._network.setData([]);
@@ -529,10 +555,10 @@ export default class NeoVis {
 		this.render(query);
 	}
 
-// configure exports based on environment (ie Node.js or browser)
-//if (typeof exports === 'object') {
-//    module.exports = NeoVis;
-//} else {
-//    define (function () {return NeoVis;})
-//}
+	// configure exports based on environment (ie Node.js or browser)
+	//if (typeof exports === 'object') {
+	//    module.exports = NeoVis;
+	//} else {
+	//    define (function () {return NeoVis;})
+	//}
 }

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -18,14 +18,14 @@ export default class NeoVis {
 	 * Get current vis nodes from the graph
 	 */
 	get nodes() {
-		return this._nodes;
+		return this._data.nodes;
 	}
 
 	/**
 	 * Get current vis edges from the graph
 	 */
 	get edges() {
-		return this._edges;
+		return this._data.edges;
 	}
 
 	/**

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -430,7 +430,7 @@ export default class NeoVis {
 						},
 						10000
 					);
-					this._events.generateEvent(CompletionEvent, {record_count: recordCount});
+					this._events.generateEvent(CompletionEvent, {record_count: recordCount, nodes: this._nodes, edges: this._edges});
 
 					let neoVis = this;
 					this._network.on('click', function (params) {

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -15,6 +15,20 @@ export default class NeoVis {
 	_events = new EventController();
 
 	/**
+	 * Get current nodes from the graph
+	 */
+	get nodes() {
+    return this._nodes;
+	}
+	
+	/**
+	 * Get current edges from the graph
+	 */
+	get edges() {
+    return this._edges;
+  }
+
+	/**
 	 *
 	 * @constructor
 	 * @param {object} config - configures the visualization and Neo4j server connection
@@ -430,7 +444,7 @@ export default class NeoVis {
 						},
 						10000
 					);
-					this._events.generateEvent(CompletionEvent, {record_count: recordCount, nodes: this._nodes, edges: this._edges});
+					this._events.generateEvent(CompletionEvent, {record_count: recordCount});
 
 					let neoVis = this;
 					this._network.on('click', function (params) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6475,6 +6475,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vis-data@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vis-data/-/vis-data-7.0.0.tgz#71ff8ec06e4d0b99f1c8cdecfdf97309eb4562cf"
+  integrity sha512-qKpyAQ9UMT0QygLbCulgabKkgfo8aVkuWSqhvEiaah/iy/Dvj17iMFChUU+UIioorWlweXcp5ziXoMLIl7hTAg==
+
 vis-network@^7.3.5:
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/vis-network/-/vis-network-7.10.2.tgz#b318f1907cf006d9640c4c31a262e0782405a3cf"


### PR DESCRIPTION
Hi!

Neovis does currently not support to receive the query results outside of the graph, for example to display the results as a table or list. In order to get the results, a second identical query would be necessary. 

I added nodes and edges to the event data object for `CompletionEvent `, so that event listeners can use this data directly without submitting a second query.

As this is my first contribution on GitHub, please let me know if I didn't follow the right proceudre and I will try to fix it! :-)

Best regards
Chris